### PR TITLE
swift template generation fix

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift4Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift4Codegen.java
@@ -69,7 +69,7 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
     protected boolean lenientTypeCast = false;
     protected boolean swiftUseApiNamespace;
     protected String[] responseAs = new String[0];
-    protected String sourceFolder = "Classes" + File.separator + "OpenAPIs";
+    protected String sourceFolder = "Sources";
     protected HashSet objcReservedWords;
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
@@ -143,7 +143,6 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
                         "Array",
                         "Dictionary",
                         "Set",
-                        "Any",
                         "Empty",
                         "AnyObject",
                         "Any",
@@ -226,7 +225,7 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("float", "Float");
         typeMapping.put("number", "Double");
         typeMapping.put("double", "Double");
-        typeMapping.put("object", "Any");
+        typeMapping.put("object", "Data");
         typeMapping.put("file", "URL");
         typeMapping.put("binary", "URL");
         typeMapping.put("ByteArray", "Data");
@@ -363,7 +362,6 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
         } else {
             additionalProperties.put(PROJECT_NAME, projectName);
         }
-        sourceFolder = projectName + File.separator + sourceFolder;
 
         // Setup nonPublicApi option, which generates code with reduced access
         // modifiers; allows embedding elsewhere without exposing non-public API calls
@@ -443,6 +441,15 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("AlamofireImplementations.mustache",
                 sourceFolder,
                 "AlamofireImplementations.swift"));
+        supportingFiles.add(new SupportingFile("AlamofireObjectMapper.mustache",
+                sourceFolder,
+                "AlamofireObjectMapper.swift"));
+        supportingFiles.add(new SupportingFile("YatAuthenticator.mustache",
+                sourceFolder,
+                "YatAuthenticator.swift"));
+        supportingFiles.add(new SupportingFile("YatCredentials.mustache",
+                sourceFolder,
+                "YatCredentials.swift"));
         supportingFiles.add(new SupportingFile("Configuration.mustache",
                 sourceFolder,
                 "Configuration.swift"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -75,7 +75,7 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
     protected boolean readonlyProperties = false;
     protected boolean swiftUseApiNamespace;
     protected String[] responseAs = new String[0];
-    protected String sourceFolder = "Classes" + File.separator + "OpenAPIs";
+    protected String sourceFolder = "Sources";
     protected HashSet objcReservedWords;
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
@@ -128,7 +128,6 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
                         "Array",
                         "Dictionary",
                         "Set",
-                        "Any",
                         "Empty",
                         "AnyObject",
                         "Any",
@@ -212,7 +211,7 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
         typeMapping.put("float", "Float");
         typeMapping.put("number", "Double");
         typeMapping.put("double", "Double");
-        typeMapping.put("object", "Any");
+        typeMapping.put("object", "Data");
         typeMapping.put("file", "URL");
         typeMapping.put("binary", "URL");
         typeMapping.put("ByteArray", "Data");
@@ -357,7 +356,6 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
         } else {
             additionalProperties.put(PROJECT_NAME, projectName);
         }
-        sourceFolder = projectName + File.separator + sourceFolder;
 
         // Setup nonPublicApi option, which generates code with reduced access
         // modifiers; allows embedding elsewhere without exposing non-public API calls
@@ -482,6 +480,15 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
                 supportingFiles.add(new SupportingFile("AlamofireImplementations.mustache",
                         sourceFolder,
                         "AlamofireImplementations.swift"));
+                supportingFiles.add(new SupportingFile("AlamofireObjectMapper.mustache",
+                        sourceFolder,
+                "AlamofireObjectMapper.swift"));
+                supportingFiles.add(new SupportingFile("YatAuthenticator.mustache",
+                        sourceFolder,
+                "YatAuthenticator.swift"));
+                supportingFiles.add(new SupportingFile("YatCredentials.mustache",
+                        sourceFolder,
+                "YatCredentials.swift"));
                 break;
             case LIBRARY_URLSESSION:
                 additionalProperties.put("useURLSession", true);

--- a/samples/client/petstore/swift5/alamofireLibrary/.openapi-generator/FILES
+++ b/samples/client/petstore/swift5/alamofireLibrary/.openapi-generator/FILES
@@ -11,6 +11,9 @@ PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
 PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
 PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
 PetstoreClient/Classes/OpenAPIs/AlamofireImplementations.swift
+PetstoreClient/Classes/OpenAPIs/YatAuthenticator.swift
+PetstoreClient/Classes/OpenAPIs/YatCredentials.swift
+PetstoreClient/Classes/OpenAPIs/AlamofireObjectMapper.swift
 PetstoreClient/Classes/OpenAPIs/CodableHelper.swift
 PetstoreClient/Classes/OpenAPIs/Configuration.swift
 PetstoreClient/Classes/OpenAPIs/Extensions.swift


### PR DESCRIPTION
changed unsupported Any type to Data
added AlamofireObjectMapper, YatAuthenticator, YatCredentials file paths for generation.
To check you need use new package for build new SDK version. 
Note: you need changes from this PR: https://github.com/tari-labs/tari-docs/pull/9
